### PR TITLE
Evergreen(ish) react-schemaorg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "react-schemaorg",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/prop-types": {
-      "version": "15.5.8",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.8.tgz",
-      "integrity": "sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
+      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==",
       "dev": true
     },
     "@types/react": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.0.tgz",
-      "integrity": "sha512-phBajeyF9ZIYGWUHJV1+X5GHOtdUO0+qHamY4PXFPf6ntoDfW+VqOG8oyruD2K4rqApfOB1QKuQiNYUX8ejEpQ==",
+      "version": "16.8.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.18.tgz",
+      "integrity": "sha512-lUXdKzRqWR4FebR5tGHkLCqnvQJS4fdXKCBrNGGbglqZg2gpU+J82pMONevQODUotATs9fc9k66bx3/St8vReg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -44,9 +44,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.2.tgz",
-      "integrity": "sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.4.tgz",
+      "integrity": "sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg==",
       "dev": true
     },
     "encoding": {
@@ -168,9 +168,9 @@
       "dev": true
     },
     "schema-dts": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-0.3.1.tgz",
-      "integrity": "sha512-TV1lwF/pkVb+Wj+RuvceoFog4dc6yp6ZsYItjdXqXmDghllUr9/E0X4tpHPK3TdHcMWxECctBl01hVRJrEhJXg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-0.4.0.tgz",
+      "integrity": "sha512-vuQJ3s3s8vH1yl0h+b41B6/QHIcV4MLj6h9aqcpFC1O7TNUzHiY/VpmOBZT1H5J82G7ngdXNSAK7wDJ5zP08Uw==",
       "dev": true
     },
     "setimmediate": {
@@ -180,9 +180,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
-      "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-schemaorg",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "displayName": "React: Schema.org",
   "description": "Typed Schema.org JSON-LD in React",
   "authors": [
@@ -17,13 +17,13 @@
   "devDependencies": {
     "@types/react": "^16.7.22",
     "react": "^15.4.1",
-    "schema-dts": "^0.3.1",
-    "typescript": "^3.1.6"
+    "schema-dts": ">=0.4.0",
+    "typescript": ">=3.1.6"
   },
   "dependencies": {},
   "peerDependencies": {
-    "typescript": "^3.1.6",
-    "schema-dts": "^0.3.1"
+    "typescript": ">=3.1.6",
+    "schema-dts": ">=0.3.1"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
Update react-schemaorg do accept any version of schema-dts and
TypeScript above a minimum. These versions support the basic operations
required, and more recent versions of schema-dts should be automatically
accepted.

react-schemaorg requires schema-dts to have a 'WithContext' and 'Thing'
types defined. This will not change. (Famous last words)