### PR TITLE
Use a Safe JSON-LD replacer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -180,9 +180,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^16.7.22",
     "react": "^15.4.1",
     "schema-dts": ">=0.4.0",
-    "typescript": ">=3.1.6"
+    "typescript": "^3.8.3"
   },
   "dependencies": {},
   "peerDependencies": {

--- a/src/json-ld.tsx
+++ b/src/json-ld.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,58 @@ export class JsonLd<T extends Thing> extends React.Component<{
     return (
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(this.props.item) }}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(this.props.item, safeJsonLdReplacer)
+        }}
       />
     );
   }
 }
+
+type JsonValueScalar = string | boolean | number;
+type JsonValue =
+  | JsonValueScalar
+  | Array<JsonValue>
+  | { [key: string]: JsonValue };
+type JsonReplacer = (_: string, value: JsonValue) => JsonValue | undefined;
+
+/**
+ * A replacer for JSON.stringify to strip JSON-LD of illegal HTML entities
+ * per https://www.w3.org/TR/json-ld11/#restrictions-for-contents-of-json-ld-script-elements
+ */
+const safeJsonLdReplacer: JsonReplacer = (() => {
+  // Replace per https://www.w3.org/TR/json-ld11/#restrictions-for-contents-of-json-ld-script-elements
+  // Solution from https://stackoverflow.com/a/5499821/864313
+  const entities = Object.freeze({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&apos;"
+  });
+  const replace = (t: string): string =>
+    entities[t as keyof typeof entities] || t;
+
+  return (_: string, value: JsonValue): JsonValue | undefined => {
+    switch (typeof value) {
+      case "object":
+        return value; // JSON.stringify will recursively call replacer.
+      case "number":
+      case "boolean":
+      case "bigint":
+        return value; // These values are not risky.
+      case "string":
+        return value.replace(/[&<>'"]/g, replace);
+      default: {
+        // We shouldn't expect other types.
+        isNever(value);
+
+        // JSON.stringify will remove this element.
+        return undefined;
+      }
+    }
+  };
+})();
+
+// Utility: Assert never
+function isNever(_: never): void {}


### PR DESCRIPTION
Per https://www.w3.org/TR/json-ld11/#restrictions-for-contents-of-json-ld-script-elements

See the parent issue in w3c/json-ld-syntax#100 where this was created.