### PR TITLE
change build target to es5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "jsx": "react",
     "outDir": "./dist/",
-    "target": "es2015",
+    "target": "es5",
     "sourceMap": true,
     "declaration": true,
     "moduleResolution": "node",


### PR DESCRIPTION
This package has trouble with Internet Explorer 11. The reason is that it uses 'class' syntax and TS will retain that syntax when compiling to ES2015. Compiled to ES5, it works with IE11.

I propose changing the build target to extend support to IE11.