### PR TITLE
Bump react-schemaorg to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-schemaorg",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-schemaorg",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "displayName": "React: Schema.org",
   "description": "Typed Schema.org JSON-LD in React",
   "authors": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "jsx": "react",
     "outDir": "./dist/",
     "target": "es5",
+    "lib": ["ES2015"],
     "sourceMap": true,
     "declaration": true,
     "moduleResolution": "node",


### PR DESCRIPTION
w/ fixes for es5 (see #17) targetting.