### PR TITLE
Expose more type overloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-schemaorg",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-schemaorg",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/plugin-transform-react-jsx": "^7.17.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-schemaorg",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "displayName": "React: Schema.org",
   "description": "Typed Schema.org JSON-LD in React",
   "authors": [

--- a/src/json-ld.tsx
+++ b/src/json-ld.tsx
@@ -50,6 +50,9 @@ export function JsonLd<T extends Thing>(
 ): JSX.Element;
 export function JsonLd(
   props: JsonLdOptions & { item: Graph | WithContext<Thing> }
+): JSX.Element;
+export function JsonLd(
+  props: JsonLdOptions & { item: Graph | WithContext<Thing> }
 ) {
   return <script {...jsonLdScriptProps(props.item, props)} />;
 }
@@ -133,7 +136,14 @@ export function helmetJsonLdProp<T extends Thing>(
   innerHTML: string;
 };
 export function helmetJsonLdProp(
-  item: WithContext<Thing> | Graph,
+  item: Graph | WithContext<Thing>,
+  options?: JsonLdOptions
+): {
+  type: "application/ld+json";
+  innerHTML: string;
+};
+export function helmetJsonLdProp(
+  item: Graph | WithContext<Thing>,
   options: JsonLdOptions = {}
 ): {
   type: "application/ld+json";


### PR DESCRIPTION
Exposes some more type overloads to avoid the need for explicit checks of properties in `Graph` or `WithContext<Thing>` when trying to use type unions.

This overloading was added to `jsonLdScriptProps` but not `helmetJsonLdProp` or the `JsonLd` component.