### PR TITLE
Update json-ld.tsx DOM text reinterpreted as HTML

### DIFF
--- a/src/json-ld.tsx
+++ b/src/json-ld.tsx
@@ -123,7 +123,7 @@ export function helmetJsonLdProp(
   options?: JsonLdOptions
 ): {
   type: "application/ld+json";
-  innerHTML: string;
+  innerText: string;
 };
 export function helmetJsonLdProp<T extends Thing>(
   item: WithContext<T>,


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.