### PR TITLE
Update-2  json-ld.tsx DOM text reinterpreted as HTML

### DIFF
--- a/src/json-ld.tsx
+++ b/src/json-ld.tsx
@@ -130,7 +130,7 @@ export function helmetJsonLdProp<T extends Thing>(
   options?: JsonLdOptions
 ): {
   type: "application/ld+json";
-  innerHTML: string;
+  innerText: string;
 };
 export function helmetJsonLdProp(
   item: WithContext<Thing> | Graph,


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.